### PR TITLE
Add labels to select inputs in `AddQuestionModal`

### DIFF
--- a/apps/app/src/components/AddQuestionModal/AddQuestionModal.tsx
+++ b/apps/app/src/components/AddQuestionModal/AddQuestionModal.tsx
@@ -76,7 +76,7 @@ export const AddQuestionModal = (props: ComponentProps<typeof BaseModal>) => {
 				<div className="mt-10 flex flex-col gap-y-3 px-5 sm:flex-row sm:justify-evenly sm:gap-x-5">
 					<label className="flex w-full flex-col gap-2">
 						<span className="text-sm text-violet-700 dark:text-neutral-200">
-							Wybierz technologie:
+							Wybierz technologię:
 						</span>
 						<Select
 							variant="purple"

--- a/apps/app/src/components/AddQuestionModal/AddQuestionModal.tsx
+++ b/apps/app/src/components/AddQuestionModal/AddQuestionModal.tsx
@@ -74,38 +74,42 @@ export const AddQuestionModal = (props: ComponentProps<typeof BaseModal>) => {
 			</h2>
 			<form onSubmit={handleFormSubmit}>
 				<div className="mt-10 flex flex-col gap-y-3 px-5 sm:flex-row sm:justify-evenly sm:gap-x-5">
-					<Select
-						variant="purple"
-						className="w-full"
-						aria-label="Wybierz technologię"
-						value={selectData.technology || ""}
-						onChange={handleSelectChange("technology", validateTechnology)}
-					>
-						<option value="" disabled>
-							Wybierz Technologię
-						</option>
-						{Object.entries(technologiesLabel).map(([technology, label]) => (
-							<option key={technology} value={technology}>
-								{label}
+					<label className="flex w-full flex-col gap-2">
+						<span className="text-sm text-violet-700 dark:text-neutral-200">
+							Wybierz technologie:
+						</span>
+						<Select
+							variant="purple"
+							value={selectData.technology || ""}
+							onChange={handleSelectChange("technology", validateTechnology)}
+						>
+							<option value="" disabled hidden selected>
+								-
 							</option>
-						))}
-					</Select>
-					<Select
-						variant="purple"
-						className="w-full"
-						aria-label="Wybierz poziom"
-						value={selectData.level || ""}
-						onChange={handleSelectChange("level", validateLevel)}
-					>
-						<option value="" disabled>
-							Wybierz Poziom
-						</option>
-						{levels.map((level) => (
-							<option key={level} value={level}>
-								{level}
+							{Object.entries(technologiesLabel).map(([technology, label]) => (
+								<option key={technology} value={technology}>
+									{label}
+								</option>
+							))}
+						</Select>
+					</label>
+					<label className="flex w-full flex-col gap-2">
+						<span className="text-sm text-violet-700 dark:text-neutral-200">Wybierz poziom:</span>
+						<Select
+							variant="purple"
+							value={selectData.level || ""}
+							onChange={handleSelectChange("level", validateLevel)}
+						>
+							<option value="" disabled hidden selected>
+								-
 							</option>
-						))}
-					</Select>
+							{levels.map((level) => (
+								<option key={level} value={level}>
+									{level}
+								</option>
+							))}
+						</Select>
+					</label>
 				</div>
 				<QuestionEditor value={content} onChange={setContent} />
 				<div className="mt-3 flex flex-col gap-2 sm:flex-row-reverse">


### PR DESCRIPTION
I suggest to redesign a `AddQuestionModal`. This PR delivers labels for each select input within this modal and reduce potential confusion which can occur when user have selected options, but he can not see for what they refer. Also I change a little bit a behavior what happens with "placeholder" option after selecting a "correct" option.

I want to emphasise that is my point of view how we can fix that - You can also treat this PR as a flag which signals a problem with this modal.