### PR TITLE
feat(app): Add `AppTitle` component

### DIFF
--- a/apps/app/src/app/(main-layout)/authors/page.tsx
+++ b/apps/app/src/app/(main-layout)/authors/page.tsx
@@ -8,7 +8,7 @@ export default async function AuthorsPage() {
 	return (
 		<StaticPageContainer>
 			<h2 className="mb-8 text-4xl font-bold">Autorzy</h2>
-			<ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+			<ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
 				{contributors.map((contributor) => (
 					<li key={contributor.login}>
 						<Author contributor={contributor} />

--- a/apps/app/src/components/AppTitle.tsx
+++ b/apps/app/src/components/AppTitle.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Link from "next/link";
+import { useIsHome } from "../hooks/useIsHome";
+import { AppLogo } from "./AppLogo";
+
+type TitleTag = keyof Pick<JSX.IntrinsicElements, "h1" | "span">;
+
+export const AppTitle = () => {
+	const { isHome } = useIsHome();
+
+	const Tag: TitleTag = isHome ? "h1" : "span";
+
+	return (
+		<Tag>
+			<Link href={`${isHome ? "#" : "/"}`}>
+				<span className="sr-only">DevFAQ</span>
+				<AppLogo />
+			</Link>
+		</Tag>
+	);
+};

--- a/apps/app/src/components/Author/Author.tsx
+++ b/apps/app/src/components/Author/Author.tsx
@@ -25,7 +25,7 @@ export const Author = ({
 
 	return (
 		<a href={profile} target="_blank" rel="noreferrer">
-			<article className="flex flex-col items-center rounded-lg bg-neutral-100 px-3.5 py-6 shadow-[0px_1px_4px] shadow-neutral-400 active:translate-y-px dark:bg-neutral-700 dark:shadow-neutral-900">
+			<article className="flex h-full flex-col items-center rounded-lg bg-neutral-100 px-3.5 py-6 text-center shadow-[0px_1px_4px] shadow-neutral-400 active:translate-y-px dark:bg-neutral-700 dark:shadow-neutral-900">
 				<Image
 					src={avatar_url}
 					alt={`Avatar użytkownika o loginie ${login}`}

--- a/apps/app/src/components/Footer.tsx
+++ b/apps/app/src/components/Footer.tsx
@@ -3,8 +3,8 @@ import { Container } from "./Container";
 
 export const Footer = () => (
 	<footer className="bg-primary">
-		<Container className="flex h-14 items-center justify-center sm:justify-end">
-			<nav className="flex flex-wrap justify-center gap-x-7 text-sm text-white">
+		<Container className="flex items-center justify-center py-5 sm:justify-end">
+			<nav className="flex flex-wrap justify-center gap-y-4 gap-x-7 text-sm text-white">
 				<Link href="/about">Jak korzystać?</Link>
 				<Link href="/regulations">Regulamin</Link>
 				<Link href="/authors">Autorzy</Link>

--- a/apps/app/src/components/Header/Header.tsx
+++ b/apps/app/src/components/Header/Header.tsx
@@ -1,6 +1,5 @@
-import Link from "next/link";
 import { Container } from "../Container";
-import { AppLogo } from "../AppLogo";
+import { AppTitle } from "../AppTitle";
 import { HeaderNavigation } from "./HeaderNavigation";
 import { ActiveNavigationLink } from "./ActiveNagivationLink";
 import { DarkModeSwitch } from "./DarkModeSwitch";
@@ -12,9 +11,7 @@ export const Header = () => (
 			as="header"
 			className="flex h-16 items-center justify-between border-b border-violet-600 text-white"
 		>
-			<Link href="/">
-				<AppLogo />
-			</Link>
+			<AppTitle />
 			<HeaderNavigation>
 				<ActiveNavigationLink href="/about">Jak korzystać?</ActiveNavigationLink>
 				<ActiveNavigationLink href="/authors">Autorzy</ActiveNavigationLink>

--- a/apps/app/src/components/QuestionsHeader.tsx
+++ b/apps/app/src/components/QuestionsHeader.tsx
@@ -23,14 +23,14 @@ export const QuestionsHeader = ({ technology, total }: QuestionsHeaderProps) => 
 	};
 
 	return (
-		<header className="flex justify-between text-neutral-400">
-			<output>
+		<header className="flex flex-wrap items-baseline justify-between gap-3 text-neutral-400">
+			<output className="flex gap-1.5 md:gap-3">
 				<strong>{technologiesLabel[technology]}: </strong>
 				{total} {questionsPluralize(total)}
 			</output>
-			<label>
+			<label className="flex flex-wrap items-baseline gap-1.5 md:gap-3">
 				Sortuj według:
-				<Select variant="default" value={sortBy} onChange={handleSelectChange} className="ml-3">
+				<Select variant="default" value={sortBy} onChange={handleSelectChange}>
 					{Object.entries(sortByLabels).map(([sortBy, label]) => (
 						<option key={sortBy} value={sortBy}>
 							{label}

--- a/apps/app/src/components/Select/Select.tsx
+++ b/apps/app/src/components/Select/Select.tsx
@@ -5,7 +5,7 @@ const variants = {
 	default:
 		"select bg-white py-1 pl-1 pr-6 text-neutral-700 dark:bg-white-dark dark:text-neutral-200",
 	purple:
-		"select-purple dark:select border-b border-primary bg-transparent py-2 pr-6 pl-1 capitalize text-primary transition-shadow duration-100 focus:shadow-[0_0_10px] focus:shadow-primary dark:border-neutral-200 dark:text-neutral-200 dark:focus:shadow-white dark:bg-white-dark",
+		"select-purple dark:select border-b border-primary bg-transparent py-2 pr-6 pl-1 capitalize text-primary  dark:border-neutral-200 dark:text-neutral-200",
 };
 
 type SelectProps = Readonly<{
@@ -16,7 +16,7 @@ type SelectProps = Readonly<{
 export const Select = ({ variant, className, ...props }: SelectProps) => (
 	<select
 		className={twMerge(
-			"cursor-pointer appearance-none rounded-none text-base focus:outline-0",
+			"cursor-pointer appearance-none rounded-none text-base transition-shadow duration-100 focus:shadow-[0_0_10px] focus:shadow-primary focus:outline-0 dark:bg-white-dark dark:focus:shadow-white",
 			variants[variant],
 			className,
 		)}

--- a/apps/app/src/hooks/useIsHome.ts
+++ b/apps/app/src/hooks/useIsHome.ts
@@ -6,10 +6,10 @@ export const useIsHome = (home = "questions") => {
 	const pathname = usePathname();
 
 	useEffect(() => {
-		if (pathname && pathname.split("/")[1] === "questions") {
+		if (pathname && pathname.split("/")[1] === home) {
 			setIsHome(true);
 		}
-	}, [pathname]);
+	}, [pathname, home]);
 
 	return { isHome };
 };

--- a/apps/app/src/hooks/useIsHome.ts
+++ b/apps/app/src/hooks/useIsHome.ts
@@ -1,0 +1,15 @@
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export const useIsHome = (home = "questions") => {
+	const [isHome, setIsHome] = useState(false);
+	const pathname = usePathname();
+
+	useEffect(() => {
+		if (pathname && pathname.split("/")[1] === "questions") {
+			setIsHome(true);
+		}
+	}, [pathname]);
+
+	return { isHome };
+};


### PR DESCRIPTION
Add `AppTitle` component with `useIsHome` hook. Component dispalys as `span` or `h1` tag depending on current pathname. The purpose of creating this component was to improve SEO by providing a tool to help maintain a more semantic hierarchy of `H` tags on each page.