### PR TITLE
feat(app): add AppTitle component

### DIFF
--- a/apps/app/src/app/(main-layout)/about/page.tsx
+++ b/apps/app/src/app/(main-layout)/about/page.tsx
@@ -4,8 +4,8 @@ export default function AboutPage() {
 	return (
 		<StaticPageContainer>
 			<article className="prose dark:prose-invert">
-				<h2>Jak korzystać? FAQ</h2>
-				<h3>Co to jest DevFAQ.pl?</h3>
+				<h1>Jak korzystać? FAQ</h1>
+				<h2>Co to jest DevFAQ.pl?</h2>
 				<p>
 					DevFAQ.pl jest serwisem internetowym służącym do udostępniania i wymiany pytań
 					rekrutacyjnych na stanowiska developerów oraz inne pokrewne. Został stworzony przez
@@ -13,14 +13,14 @@ export default function AboutPage() {
 					przygotowania się do rozmów rekrutacyjnych.
 				</p>
 
-				<h3>Jak można dodać pytanie?</h3>
+				<h2>Jak można dodać pytanie?</h2>
 				<p>
 					Każdy użytkownik DevFAQ może dodać treść pytania, przydzielić mu kategorię oraz poziom
 					trudności. Następnie po kliknięciu „Dodaj” pytanie trafia do moderacji. Po zaakceptowaniu
 					przez administratorów, pojawi się na stronie. Może to zająć kilka dni!
 				</p>
 
-				<h3>Jakie są ogólne zasady korzystania z serwisu?</h3>
+				<h2>Jakie są ogólne zasady korzystania z serwisu?</h2>
 				<ul>
 					<li>W treści nie podawaj nazwy firmy, w której padło pytanie.</li>
 					<li>
@@ -37,7 +37,7 @@ export default function AboutPage() {
 					</li>
 				</ul>
 
-				<h3>Czy mogę formatować jakoś treść dodawanych pytań?</h3>
+				<h2>Czy mogę formatować jakoś treść dodawanych pytań?</h2>
 				<p>Tak! Możesz skorzystać z powszechnie znanego Markdown:</p>
 				<ul>
 					<li>``` Code block ```</li>

--- a/apps/app/src/app/(main-layout)/authors/page.tsx
+++ b/apps/app/src/app/(main-layout)/authors/page.tsx
@@ -7,7 +7,7 @@ export default async function AuthorsPage() {
 
 	return (
 		<StaticPageContainer>
-			<h2 className="mb-8 text-4xl font-bold">Autorzy</h2>
+			<h1 className="mb-8 text-4xl font-bold">Autorzy</h1>
 			<ul className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
 				{contributors.map((contributor) => (
 					<li key={contributor.login}>

--- a/apps/app/src/components/AppTitle.tsx
+++ b/apps/app/src/components/AppTitle.tsx
@@ -4,11 +4,11 @@ import Link from "next/link";
 import { useIsHome } from "../hooks/useIsHome";
 import { AppLogo } from "./AppLogo";
 
-type TitleTag = keyof Pick<JSX.IntrinsicElements, "h1" | "span">;
+type TitleTag = keyof Pick<JSX.IntrinsicElements, "h1" | "div">;
 
 export const AppTitle = () => {
 	const isHome = useIsHome();
-	const Tag: TitleTag = isHome ? "h1" : "span";
+	const Tag: TitleTag = isHome ? "h1" : "div";
 
 	return (
 		<Tag>

--- a/apps/app/src/components/AppTitle.tsx
+++ b/apps/app/src/components/AppTitle.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Link from "next/link";
+import { useIsHome } from "../hooks/useIsHome";
+import { AppLogo } from "./AppLogo";
+
+type TitleTag = keyof Pick<JSX.IntrinsicElements, "h1" | "span">;
+
+export const AppTitle = () => {
+	const { isHome } = useIsHome();
+
+	const Tag: TitleTag = isHome ? "h1" : "span";
+
+	return (
+		<Tag>
+			<Link href={`${isHome ? "#" : "/"}`}>
+				<span className="sr-only">DevFAQ</span>
+				<AppLogo />
+			</Link>
+		</Tag>
+	);
+};

--- a/apps/app/src/components/AppTitle.tsx
+++ b/apps/app/src/components/AppTitle.tsx
@@ -4,11 +4,9 @@ import Link from "next/link";
 import { useIsHome } from "../hooks/useIsHome";
 import { AppLogo } from "./AppLogo";
 
-type TitleTag = keyof Pick<JSX.IntrinsicElements, "h1" | "div">;
-
 export const AppTitle = () => {
 	const isHome = useIsHome();
-	const Tag: TitleTag = isHome ? "h1" : "div";
+	const Tag = isHome ? "h1" : "div";
 
 	return (
 		<Tag>

--- a/apps/app/src/components/AppTitle.tsx
+++ b/apps/app/src/components/AppTitle.tsx
@@ -7,8 +7,7 @@ import { AppLogo } from "./AppLogo";
 type TitleTag = keyof Pick<JSX.IntrinsicElements, "h1" | "span">;
 
 export const AppTitle = () => {
-	const { isHome } = useIsHome();
-
+	const isHome = useIsHome();
 	const Tag: TitleTag = isHome ? "h1" : "span";
 
 	return (

--- a/apps/app/src/components/Header/Header.tsx
+++ b/apps/app/src/components/Header/Header.tsx
@@ -1,6 +1,5 @@
-import Link from "next/link";
 import { Container } from "../Container";
-import { AppLogo } from "../AppLogo";
+import { AppTitle } from "../AppTitle";
 import { HeaderNavigation } from "./HeaderNavigation";
 import { ActiveNavigationLink } from "./ActiveNagivationLink";
 import { DarkModeSwitch } from "./DarkModeSwitch";
@@ -12,9 +11,7 @@ export const Header = () => (
 			as="header"
 			className="flex h-16 items-center justify-between border-b border-violet-600 text-white"
 		>
-			<Link href="/">
-				<AppLogo />
-			</Link>
+			<AppTitle />
 			<HeaderNavigation>
 				<ActiveNavigationLink href="/about">Jak korzystać?</ActiveNavigationLink>
 				<ActiveNavigationLink href="/authors">Autorzy</ActiveNavigationLink>

--- a/apps/app/src/hooks/useIsHome.ts
+++ b/apps/app/src/hooks/useIsHome.ts
@@ -1,0 +1,15 @@
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export const useIsHome = (home = "questions") => {
+	const [isHome, setIsHome] = useState(false);
+	const pathname = usePathname();
+
+	useEffect(() => {
+		if (pathname && pathname.split("/")[1] === home) {
+			setIsHome(true);
+		}
+	}, [pathname, home]);
+
+	return { isHome };
+};

--- a/apps/app/src/hooks/useIsHome.ts
+++ b/apps/app/src/hooks/useIsHome.ts
@@ -1,15 +1,10 @@
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
 
 export const useIsHome = (home = "questions") => {
-	const [isHome, setIsHome] = useState(false);
 	const pathname = usePathname();
 
-	useEffect(() => {
-		if (pathname && pathname.split("/")[1] === home) {
-			setIsHome(true);
-		}
-	}, [pathname, home]);
-
-	return { isHome };
+	if (pathname && pathname.split("/")[1] === home) {
+		return true;
+	}
+	return false;
 };


### PR DESCRIPTION
Add `AppTitle` component with `useIsHome` hook. Component dispalys as `span` or `h1` tag depending on current pathname. The purpose of creating this component was to improve SEO by providing a tool to help maintain a more semantic hierarchy of `H` tags on each page.