### PR TITLE
fix(app): fix position of all items in HeaderNavigation on mobile

### DIFF
--- a/apps/app/src/components/Header/Header.tsx
+++ b/apps/app/src/components/Header/Header.tsx
@@ -18,7 +18,7 @@ export const Header = () => (
 				<a href="https://www.facebook.com/DevFAQ" target="_blank" rel="noreferrer">
 					FaceBook
 				</a>
-				<div className="md:w-14">
+				<div className="sm:w-14">
 					<LoginNavigationLink />
 				</div>
 				<DarkModeSwitch />

--- a/apps/app/src/components/Header/Header.tsx
+++ b/apps/app/src/components/Header/Header.tsx
@@ -18,7 +18,7 @@ export const Header = () => (
 				<a href="https://www.facebook.com/DevFAQ" target="_blank" rel="noreferrer">
 					FaceBook
 				</a>
-				<div className="w-14">
+				<div className="md:w-14">
 					<LoginNavigationLink />
 				</div>
 				<DarkModeSwitch />


### PR DESCRIPTION
This PR fix position of 'zaloguj' link in navigation on mobile devices.

Issue:

![devfaq-k438js9gw-typeofweb](https://user-images.githubusercontent.com/27455716/208315978-073fdea3-7366-4541-8a7c-823383806b80.png)
