### PR TITLE
fix(app): pagination improvements

### DIFF
--- a/apps/app/src/app/(main-layout)/questions/[technology]/[page]/page.tsx
+++ b/apps/app/src/app/(main-layout)/questions/[technology]/[page]/page.tsx
@@ -46,11 +46,13 @@ export default async function QuestionsPage({
 		<div className="flex flex-col gap-y-10">
 			<QuestionsHeader technology={params.technology} total={meta.total} />
 			<QuestionsList questions={questions} questionFilter={questionFilter} />
-			<QuestionsPagination
-				current={page}
-				total={meta.total}
-				getHref={(page) => `/questions/${params.technology}/${page}`}
-			/>
+			{meta.total > PAGE_SIZE && (
+				<QuestionsPagination
+					current={page}
+					total={meta.total}
+					getHref={(page) => `/questions/${params.technology}/${page}`}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/app/src/components/ActiveLink.tsx
+++ b/apps/app/src/components/ActiveLink.tsx
@@ -28,8 +28,8 @@ export const ActiveLink = ({
 		<LinkWithQuery
 			href={href}
 			className={twMerge(className, isActive && activeClassName)}
-			{...(isActive && activeAttributes)}
 			{...props}
+			{...(isActive && activeAttributes)}
 		/>
 	);
 };

--- a/apps/app/src/components/QuestionsPagination/QuestionsPagination.tsx
+++ b/apps/app/src/components/QuestionsPagination/QuestionsPagination.tsx
@@ -38,21 +38,26 @@ export const QuestionsPagination = ({ current, total, getHref }: QuestionsPagina
 	});
 
 	return (
-		<nav aria-label="Paginacja" className="flex justify-center gap-x-3">
-			{pages.map((i) => (
-				<ActiveLink
-					key={i}
-					href={getHref(i)}
-					className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-full border-2 border-primary text-primary transition-colors duration-300 hover:bg-violet-100 dark:text-white dark:hover:bg-violet-800"
-					activeClassName="bg-primary text-white hover:bg-primary"
-					activeAttributes={{
-						"aria-current": "page",
-					}}
-					mergeQuery
-				>
-					<span className="sr-only">Strona</span> {i}
-				</ActiveLink>
-			))}
+		<nav aria-label="Paginacja" role="navigation">
+			<ul className="flex justify-center gap-x-3">
+				{pages.map((i) => (
+					<li key={i}>
+						<ActiveLink
+							href={getHref(i)}
+							className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-full border-2 border-primary text-primary transition-colors duration-300 hover:bg-violet-100 dark:text-white dark:hover:bg-violet-800"
+							activeClassName="bg-primary text-white hover:bg-primary"
+							aria-label={`Strona ${i}`}
+							activeAttributes={{
+								"aria-current": "page",
+								"aria-label": `Strona ${i}, bieżąca`,
+							}}
+							mergeQuery
+						>
+							{i}
+						</ActiveLink>
+					</li>
+				))}
+			</ul>
 		</nav>
 	);
 };

--- a/apps/app/src/components/QuestionsPagination/QuestionsPagination.tsx
+++ b/apps/app/src/components/QuestionsPagination/QuestionsPagination.tsx
@@ -47,7 +47,7 @@ export const QuestionsPagination = ({ current, total, getHref }: QuestionsPagina
 							className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-full border-2 border-primary text-primary transition-colors duration-300 hover:bg-violet-100 dark:text-white dark:hover:bg-violet-800"
 							activeClassName="bg-primary text-white hover:bg-primary"
 							aria-label={`Strona ${i}${
-								current - 1 === i ? ", poprzednia" : current + 1 == i ? ", kolejna" : ""
+								current - 1 === i ? ", poprzednia" : current + 1 === i ? ", kolejna" : ""
 							}`}
 							activeAttributes={{
 								"aria-current": "page",

--- a/apps/app/src/components/QuestionsPagination/QuestionsPagination.tsx
+++ b/apps/app/src/components/QuestionsPagination/QuestionsPagination.tsx
@@ -46,7 +46,9 @@ export const QuestionsPagination = ({ current, total, getHref }: QuestionsPagina
 							href={getHref(i)}
 							className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-full border-2 border-primary text-primary transition-colors duration-300 hover:bg-violet-100 dark:text-white dark:hover:bg-violet-800"
 							activeClassName="bg-primary text-white hover:bg-primary"
-							aria-label={`Strona ${i}`}
+							aria-label={`Strona ${i}${
+								current - 1 === i ? ", poprzednia" : current + 1 == i ? ", kolejna" : ""
+							}`}
 							activeAttributes={{
 								"aria-current": "page",
 								"aria-label": `Strona ${i}, bieżąca`,


### PR DESCRIPTION
PR change:
- hides pagination in case when the given category have not more questions to display than limit for each page which is 20 at this moment,
- improve accessibility of pagination (add some `aria-*` attributes and improve previously added),
- turn pagination into html list for better html semantic.