### PR TITLE
fix(app): fix colors

### DIFF
--- a/apps/app/src/styles/variables.css
+++ b/apps/app/src/styles/variables.css
@@ -1,6 +1,4 @@
 :root {
-	--primary: theme("colors.violet.700");
-
 	--junior-light-color: oklch(99.9% 0.2 255);
 	--junior-main-color: oklch(70% 0.2 255);
 	--junior-main-color-dark: oklch(62% 0.2 255);
@@ -18,11 +16,29 @@
 	--senior-main-color-dark: oklch(72.5% 0.18 85);
 	--senior-main-color-darker: oklch(59.5% 0.18 85);
 	--senior-main-color-light: oklch(88.5% 0.18 85);
+
+	--violet-50: oklch(95% 0.017 295);
+	--violet-100: oklch(87% 0.047 295);
+	--violet-200: oklch(85.5% 0.045 295);
+	--violet-300: oklch(78% 0.091 295);
+	--violet-400: oklch(68% 0.137 295);
+	--violet-500: oklch(59% 0.179 295);
+	--violet-600: oklch(50.5% 0.212 295);
+	--violet-700: oklch(47.5% 0.186 295);
+	--violet-800: oklch(34.5% 0.166 295);
+	--violet-900: oklch(34% 0.09 295);
+
+	--primary: var(--violet-700);
+
+	--white-dark: oklch(31% 0 0);
+	--red-branding: oklch(58% 0.21 17);
+	--red-branding-dark: oklch(54% 0.21 17);
+
+	--yellow-branding: oklch(83% 0.17 80);
+	--yellow-branding-dark: oklch(79% 0.17 80);
 }
 
 :root.dark {
-	--primary: theme("colors.violet.800");
-
 	--junior-light-color: oklch(45.5% 0 0);
 	--junior-main-color: oklch(54.5% 0.18 255);
 	--junior-main-color-dark: oklch(44.5% 0.18 255);
@@ -40,4 +56,6 @@
 	--senior-main-color-dark: oklch(45% 0.8 82);
 	--senior-main-color-darker: oklch(29% 0.8 82);
 	--senior-main-color-light: oklch(71.5% 0.8 82);
+
+	--primary: var(--violet-800);
 }

--- a/apps/app/tailwind.config.js
+++ b/apps/app/tailwind.config.js
@@ -7,15 +7,15 @@ module.exports = {
 	theme: {
 		extend: {
 			colors: {
-				"white-dark": "oklch(31% 0 0)",
+				"white-dark": "var(--white-dark)",
 				primary: "var(--primary)",
 				red: {
-					branding: "oklch(58% 0.21 17)",
-					"branding-dark": "oklch(54% 0.21 17)",
+					branding: "var(--red-branding)",
+					"branding-dark": "var(--red-branding-dark)",
 				},
 				yellow: {
-					branding: "oklch(83% 0.17 80)",
-					"branding-dark": "oklch(79% 0.17 80)",
+					branding: "var(--yellow-branding)",
+					"branding-dark": "var(--yellow-branding-dark)",
 				},
 				junior: {
 					light: "var(--junior-light-color)",
@@ -39,16 +39,16 @@ module.exports = {
 					"main-light": "var(--senior-main-color-light)",
 				},
 				violet: {
-					50: "oklch(95% 0.017 295)",
-					100: "oklch(87% 0.047 295)",
-					200: "oklch(85.5% 0.045 295)",
-					300: "oklch(78% 0.091 295)",
-					400: "oklch(68% 0.137 295)",
-					500: "oklch(59% 0.179 295)",
-					600: "oklch(50.5% 0.212 295)",
-					700: "oklch(47.5% 0.186 295)",
-					800: "oklch(34.5% 0.166 295)",
-					900: "oklch(34% 0.09 295)",
+					50: "var(--violet-50)",
+					100: "var(--violet-100)",
+					200: "var(--violet-200)",
+					300: "var(--violet-300)",
+					400: "var(--violet-400)",
+					500: "var(--violet-500)",
+					600: "var(--violet-600)",
+					700: "var(--violet-700)",
+					800: "var(--violet-800)",
+					900: "var(--violet-900)",
 				},
 			},
 			fontFamily: {


### PR DESCRIPTION
Fixes: #487 

TL;DR: eliminacja fallback styles na rzecz zmiennych css w blokach `@supports`.

cssnano-simple, który jest wykorzystywany przez next.js do optymalizacji  produkcyjnego kodu css, usuwa fallback style dla koloru obramowań traktując je jako zduplikowany kod. Trzymanie wszystkich kolorów w zmiennych css pozwala na wyeliminowanie tych konfliktów, ponieważ wtyczka postCSS '@csstools/postcss-oklab-function' automatycznie konwertuje oklch na rgb oraz dodaje blok `@supports` z wartością oklch - dzięki temu przeglądarka sama decyduje czy używać bloku z zmiennymi zawierającymi kolory w rgb, czy oklch.