### PR TITLE
fix: update questions list after edit any of them in user dashboard

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
 	},
 	"[prisma]": {
 		"editor.defaultFormatter": "Prisma.prisma"
-	}
+	},
+	"prettier.configPath": "prettier.config.js"
 }

--- a/apps/app/src/components/AdminPanel/AdminPanel.tsx
+++ b/apps/app/src/components/AdminPanel/AdminPanel.tsx
@@ -17,7 +17,7 @@ type AdminPanelProps = Readonly<{
 }>;
 
 export const AdminPanel = ({ page, technology, levels, status }: AdminPanelProps) => {
-	const { isSuccess, data, refetch, isLoading } = useGetAllQuestions({
+	const { isSuccess, data, refetch } = useGetAllQuestions({
 		page,
 		status,
 		technology,

--- a/apps/app/src/components/AdminPanel/AdminPanel.tsx
+++ b/apps/app/src/components/AdminPanel/AdminPanel.tsx
@@ -6,6 +6,7 @@ import { Level } from "../../lib/level";
 import { QuestionStatus } from "../../lib/question";
 import { Technology } from "../../lib/technologies";
 import { FilterableQuestionsList } from "../FilterableQuestionsList/FilterableQuestionsList";
+import { Loading } from "../Loading";
 import { AdminPanelQuestionsList } from "./AdminPanelQuestionsList";
 
 type AdminPanelProps = Readonly<{
@@ -16,7 +17,7 @@ type AdminPanelProps = Readonly<{
 }>;
 
 export const AdminPanel = ({ page, technology, levels, status }: AdminPanelProps) => {
-	const { isSuccess, data, refetch } = useGetAllQuestions({
+	const { isSuccess, data, refetch, isLoading } = useGetAllQuestions({
 		page,
 		status,
 		technology,
@@ -35,7 +36,7 @@ export const AdminPanel = ({ page, technology, levels, status }: AdminPanelProps
 			data={{ status, technology, levels }}
 		>
 			{isSuccess && data.data.data.length > 0 ? (
-				<Suspense>
+				<Suspense fallback={<Loading label="ładowanie pytań" />}>
 					<AdminPanelQuestionsList questions={data.data.data} refetchQuestions={refetchQuestions} />
 				</Suspense>
 			) : (

--- a/apps/app/src/components/UserQuestions/UserQuestionLeftSection.tsx
+++ b/apps/app/src/components/UserQuestions/UserQuestionLeftSection.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useUIContext } from "../../providers/UIProvider";
 import { AdminQuestion } from "../../types";
 import PencilIcon from "../../../public/icons/pencil.svg";
@@ -5,10 +6,20 @@ import { Button } from "../Button/Button";
 
 type UserQuestionLeftSectionProps = Readonly<{
 	question: AdminQuestion;
+	refetchQuestions: () => void;
 }>;
 
-export const UserQuestionLeftSection = ({ question }: UserQuestionLeftSectionProps) => {
-	const { openModal } = useUIContext();
+export const UserQuestionLeftSection = ({
+	question,
+	refetchQuestions,
+}: UserQuestionLeftSectionProps) => {
+	const { openModal, openedModal } = useUIContext();
+
+	useEffect(() => {
+		if (!openedModal) {
+			refetchQuestions();
+		}
+	}, [openedModal, refetchQuestions]);
 
 	return (
 		<div className="mr-3 flex flex-col justify-start gap-1.5">

--- a/apps/app/src/components/UserQuestions/UserQuestions.tsx
+++ b/apps/app/src/components/UserQuestions/UserQuestions.tsx
@@ -5,6 +5,7 @@ import { useGetAllQuestions } from "../../hooks/useGetAllQuestions";
 import { useUser } from "../../hooks/useUser";
 import { Technology } from "../../lib/technologies";
 import { FilterableQuestionsList } from "../FilterableQuestionsList/FilterableQuestionsList";
+import { Loading } from "../Loading";
 import { Level } from "../QuestionItem/QuestionLevel";
 import { UserQuestionsList } from "./UserQuestionsList";
 
@@ -35,7 +36,7 @@ export const UserQuestions = ({ page, technology, levels }: UserQuestionsProps) 
 			data={{ technology, levels }}
 		>
 			{isSuccess && data.data.data.length > 0 ? (
-				<Suspense>
+				<Suspense fallback={<Loading label="ładowanie pytań" />}>
 					<UserQuestionsList questions={data.data.data} refetchQuestions={refetchQuestions} />
 				</Suspense>
 			) : (

--- a/apps/app/src/components/UserQuestions/UserQuestions.tsx
+++ b/apps/app/src/components/UserQuestions/UserQuestions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useCallback } from "react";
 import { useGetAllQuestions } from "../../hooks/useGetAllQuestions";
 import { useUser } from "../../hooks/useUser";
 import { Technology } from "../../lib/technologies";
@@ -16,12 +16,16 @@ type UserQuestionsProps = Readonly<{
 
 export const UserQuestions = ({ page, technology, levels }: UserQuestionsProps) => {
 	const { userData } = useUser();
-	const { isSuccess, data } = useGetAllQuestions({
+	const { isSuccess, data, refetch } = useGetAllQuestions({
 		page,
 		technology,
 		levels,
 		userId: userData?._user.id,
 	});
+
+	const refetchQuestions = useCallback(() => {
+		void refetch();
+	}, [refetch]);
 
 	return (
 		<FilterableQuestionsList
@@ -32,7 +36,7 @@ export const UserQuestions = ({ page, technology, levels }: UserQuestionsProps) 
 		>
 			{isSuccess && data.data.data.length > 0 ? (
 				<Suspense>
-					<UserQuestionsList questions={data.data.data} />
+					<UserQuestionsList questions={data.data.data} refetchQuestions={refetchQuestions} />
 				</Suspense>
 			) : (
 				<p className="mt-10 text-2xl font-bold uppercase text-primary dark:text-neutral-200">

--- a/apps/app/src/components/UserQuestions/UserQuestionsList.tsx
+++ b/apps/app/src/components/UserQuestions/UserQuestionsList.tsx
@@ -10,9 +10,10 @@ import { UserQuestionLeftSection } from "./UserQuestionLeftSection";
 
 type UserQuestionsListProps = Readonly<{
 	questions: APIQuestion[];
+	refetchQuestions: () => void;
 }>;
 
-export const UserQuestionsList = memo(({ questions }: UserQuestionsListProps) => {
+export const UserQuestionsList = memo(({ questions, refetchQuestions }: UserQuestionsListProps) => {
 	const serializedQuestions = questions.map((question) =>
 		use(
 			(async () => {
@@ -29,7 +30,9 @@ export const UserQuestionsList = memo(({ questions }: UserQuestionsListProps) =>
 					<QuestionItem
 						level={question._levelId}
 						technology={question._categoryId}
-						leftSection={<UserQuestionLeftSection question={question} />}
+						leftSection={
+							<UserQuestionLeftSection question={question} refetchQuestions={refetchQuestions} />
+						}
 						rightSection={
 							<div className="flex flex-col items-center">
 								<QuestionTechnology technology={question._categoryId} />


### PR DESCRIPTION
PR wprowadza zmiany:
- w panelu użytkownika podobnie, jak w panelu admina, po edycji pytania lista pytań jest odświeżana, aby można było zobaczyć wprowadzone zmiany,
- dodanie ścieżki do pliku konfiguracyjnego prettiera do ustawień workspace vsc.